### PR TITLE
Sdk 123 review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Python SDK
 
-Version: ionosenterprise-sdk-python **5.2.0**
+Version: ionosenterprise-sdk-python **5.3.0**
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -2483,6 +2483,7 @@ The following table describes the request arguments:
 | node_count | **yes** | int | Number of nodes part of the Node Pool |
 | maintenance_window | no | dict | The time to use for a maintenance window. Accepted formats are: HH:mm:ss; HH:mm:ss"Z"; HH:mm:ssZ. This time may varies by 15 minutes. |
 | auto_scaling | no | dict | The minimum number of worker nodes that the managed node group can scale in. |
+| lan_ids | no | List of ints | Array of additional LANs attached to worker nodes |
 
 Method signature:
 
@@ -2502,7 +2503,8 @@ client.update_k8s_cluster_nodepool(
     maintenance_window={
         'dayOfTheWeek': "Monday",
         'time': '17:00:00'},
-    auto_scaling={'minNodeCount': 2, 'maxNodeCount': 3}
+    auto_scaling={'minNodeCount': 2, 'maxNodeCount': 3},
+    lan_ids=[2,3]
 )
 ```
 ---

--- a/README.md
+++ b/README.md
@@ -2504,7 +2504,7 @@ client.update_k8s_cluster_nodepool(
         'dayOfTheWeek': "Monday",
         'time': '17:00:00'},
     auto_scaling={'minNodeCount': 2, 'maxNodeCount': 3},
-    lan_ids=[2,3]
+    lan_ids=[2, 3]
 )
 ```
 ---

--- a/README.md
+++ b/README.md
@@ -1241,6 +1241,7 @@ Pass the object and arguments to `create_lan`:
 | name | no | string | The name of your LAN. |
 | public | **Yes** | bool | Boolean indicating if the LAN faces the public Internet or not. |
 | nics | no | list | One or more NIC IDs attached to the LAN. |
+| pcc | no | string | Unique identifier of the private cross connect the given LAN is connected to if any. |
 
 ---
 

--- a/ionosenterprise/__init__.py
+++ b/ionosenterprise/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Ionos Enterprise API Client Library for Python"""
-__version__ = '5.2.0'
+__version__ = '5.3.0'
 
 API_HOST = 'https://api.ionos.com/cloudapi/v5'
 API_VERSION = '5.0'

--- a/ionosenterprise/items/lan.py
+++ b/ionosenterprise/items/lan.py
@@ -16,8 +16,8 @@ class LAN(object):
         :param      nics: A list of NICs
         :type       nics: ``list``
 
-        :param      pcc: Unique identifier of the private cross connect the given LAN is connected to if any
-        :type       pcc: ``str``
+        :param      pcc_id: Unique identifier of the private cross connect the given LAN is connected to if any
+        :type       pcc_id: ``str``
 
         """
         if nics is None:

--- a/ionosenterprise/items/lan.py
+++ b/ionosenterprise/items/lan.py
@@ -3,7 +3,7 @@ class LAN(object):
     This is the main class for managing LAN resources.
     """
 
-    def __init__(self, name=None, public=None, nics=None, pcc=None):
+    def __init__(self, name=None, public=None, nics=None, pcc_id=None):
         """
         LAN class initializer.
 
@@ -25,8 +25,8 @@ class LAN(object):
         self.name = name
         self.public = public
         self.nics = nics
-        self.pcc = pcc
+        self.pcc = pcc_id
 
     def __repr__(self):
-        return (('<LAN: name=%s, public=%s, nics=%s, pcc=%s> ...>')
+        return (('<LAN: name=%s, public=%s, nics=%s, pcc_id=%s> ...>')
                 % (self.name, str(self.public), str(self.nics), str(self.pcc)))

--- a/ionosenterprise/items/lan.py
+++ b/ionosenterprise/items/lan.py
@@ -3,7 +3,7 @@ class LAN(object):
     This is the main class for managing LAN resources.
     """
 
-    def __init__(self, name=None, public=None, nics=None):
+    def __init__(self, name=None, public=None, nics=None, pcc=None):
         """
         LAN class initializer.
 
@@ -16,13 +16,17 @@ class LAN(object):
         :param      nics: A list of NICs
         :type       nics: ``list``
 
+        :param      pcc: Unique identifier of the private cross connect the given LAN is connected to if any
+        :type       pcc: ``str``
+
         """
         if nics is None:
             nics = []
         self.name = name
         self.public = public
         self.nics = nics
+        self.pcc = pcc
 
     def __repr__(self):
-        return (('<LAN: name=%s, public=%s> ...>')
-                % (self.name, str(self.public)))
+        return (('<LAN: name=%s, public=%s, nics=%s, pcc=%s> ...>')
+                % (self.name, str(self.public), str(self.nics), str(self.pcc)))

--- a/ionosenterprise/requests/dicts.py
+++ b/ionosenterprise/requests/dicts.py
@@ -12,6 +12,9 @@ class dicts:
         if lan.public is not None:
             properties['public'] = str(lan.public).lower()
 
+        if lan.pcc is not None:
+            properties['pcc'] = lan.pcc
+
         if lan.nics:
             for nic in lan.nics:
                 nics_properties = {

--- a/ionosenterprise/requests/k8s_nodepools.py
+++ b/ionosenterprise/requests/k8s_nodepools.py
@@ -43,7 +43,7 @@ class k8s_nodepools:
 
     def update_k8s_cluster_nodepool(self,
                                     k8s_cluster_id, nodepool_id, node_count,
-                                    maintenance_window=None, auto_scaling=None):
+                                    maintenance_window=None, auto_scaling=None, lan_ids=None):
         """
         This will modify the Kubernetes Node Pool.
 
@@ -83,6 +83,9 @@ class k8s_nodepools:
                                 Value for this attribute must be greater than equal to 1 and minNodeCount.
                         maxNodeCount: ``integer``
 
+        :param      lan_ids: array of additional LANs attached to worker nodes
+        :type       lan_ids: ``list of ints``
+
         """
 
         # mandatory fields
@@ -95,6 +98,8 @@ class k8s_nodepools:
             properties['maintenanceWindow'] = maintenance_window
         if auto_scaling is not None:
             properties['autoScaling'] = auto_scaling
+        if lan_ids is not None:
+            properties['lans'] = [{'id': lan_id} for lan_id in lan_ids]
 
         data = {
             'properties': properties

--- a/ionosenterprise/requests/k8s_nodepools.py
+++ b/ionosenterprise/requests/k8s_nodepools.py
@@ -99,7 +99,7 @@ class k8s_nodepools:
         if auto_scaling is not None:
             properties['autoScaling'] = auto_scaling
         if lan_ids is not None:
-            properties['lans'] = [{'id': lan_id} for lan_id in lan_ids]
+            properties['lans'] = [{'id': int(lan_id)} for lan_id in lan_ids]
 
         data = {
             'properties': properties
@@ -244,7 +244,7 @@ class k8s_nodepools:
         if auto_scaling is not None:
             properties['autoScaling'] = auto_scaling
         if lan_ids is not None:
-            properties['lans'] = [{'id':lan_id} for lan_id in lan_ids]
+            properties['lans'] = [{'id':int(lan_id)} for lan_id in lan_ids]
         if labels is not None:
             properties['labels'] = labels
         if annotations is not None:

--- a/tests/helpers/resources.py
+++ b/tests/helpers/resources.py
@@ -119,7 +119,7 @@ def resource():
         'lan': {
             # REST API converts names to lowercase.
             'name': 'python sdk test',
-            'public': True,
+            'public': False,
         },
         'ipblock': {
             # REST API converts names to lowercase.

--- a/tests/test_k8s_nodepools.py
+++ b/tests/test_k8s_nodepools.py
@@ -32,16 +32,44 @@ class TestK8sNodepools(unittest.TestCase):
         cls.datacenter = cls.client.create_datacenter(datacenter=Datacenter(**cls.resource['datacenter']))
         cls.k8s_cluster = cls.client.create_k8s_cluster(**cls.resource['k8s_cluster'])
 
+        # Wait for k8s cluster to be active
+        cls.client.wait_for(
+            fn_request=lambda: cls.client.list_k8s_clusters(),
+            fn_check=lambda r: list(filter(
+                lambda e: e['properties']['name'] == cls.resource['k8s_cluster']['name'],
+                r['items']
+            ))[0]['metadata']['state'] == 'ACTIVE',
+            scaleup=10000
+        )
+
         cls.k8s_cluster_nodepool1 = cls.client.create_k8s_cluster_nodepool(
             cls.k8s_cluster['id'],
             datacenter_id=cls.datacenter['id'],
             **cls.resource['k8s_nodepool']
         )
+
         cls.k8s_cluster_nodepool2 = cls.client.create_k8s_cluster_nodepool(
             cls.k8s_cluster['id'],
             datacenter_id=cls.datacenter['id'],
             **cls.resource['k8s_nodepool']
         )
+
+        # Wait for k8s cluster nodepool 1 to be active
+        cls.client.wait_for(
+            fn_request=lambda: cls.client.get_k8s_cluster_nodepool(cls.k8s_cluster['id'], cls.k8s_cluster_nodepool1['id']),
+            fn_check=lambda r: r['metadata']['state'] == 'ACTIVE',
+            scaleup=10000
+        )
+
+        # Wait for k8s cluster nodepool 2 to be active
+        cls.client.wait_for(
+            fn_request=lambda: cls.client.get_k8s_cluster_nodepool(cls.k8s_cluster['id'], cls.k8s_cluster_nodepool2['id']),
+            fn_check=lambda r: r['metadata']['state'] == 'ACTIVE',
+            scaleup=10000
+        )
+
+
+
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_lan.py
+++ b/tests/test_lan.py
@@ -47,7 +47,7 @@ class TestLan(unittest.TestCase):
 
         # Create test LAN.
         lan_properties = cls.resource['lan']
-        lan_properties['pcc'] = cls.pcc['id']
+        lan_properties['pcc_id'] = cls.pcc['id']
         cls.lan = cls.client.create_lan(
             datacenter_id=cls.datacenter['id'],
             lan=LAN(**lan_properties))

--- a/tests/test_lan.py
+++ b/tests/test_lan.py
@@ -90,7 +90,7 @@ class TestLan(unittest.TestCase):
         self.assertEqual(lans['items'][0]['type'], 'lan')
         self.assertIn(lans['items'][0]['id'], ('1', '2', '3'))
         self.assertEqual(lans['items'][0]['properties']['name'], self.resource['lan']['name'])
-        self.assertTrue(lans['items'][0]['properties']['public'], self.resource['lan']['public'])
+        self.assertEqual(lans['items'][0]['properties']['public'], self.resource['lan']['public'])
 
     def test_get_lan(self):
         lan = self.client.get_lan(datacenter_id=self.datacenter['id'], lan_id=self.lan['id'])
@@ -98,7 +98,7 @@ class TestLan(unittest.TestCase):
         self.assertEqual(lan['type'], 'lan')
         self.assertEqual(lan['id'], self.lan['id'])
         self.assertEqual(lan['properties']['name'], self.resource['lan']['name'])
-        self.assertTrue(lan['properties']['public'], self.resource['lan']['public'])
+        self.assertEqual(lan['properties']['public'], self.resource['lan']['public'])
 
     def test_remove_lan(self):
         lan = self.client.create_lan(
@@ -153,7 +153,7 @@ class TestLan(unittest.TestCase):
 
         self.assertEqual(response['type'], 'lan')
         self.assertEqual(response['properties']['name'], self.resource['lan']['name'])
-        self.assertTrue(response['properties']['public'])
+        self.assertFalse(response['properties']['public'])
 
     def test_get_lan_members(self):
         members = self.client.get_lan_members(


### PR DESCRIPTION
LAN/PCC: pcc_id can also be specified when a LAN is created - documentation.

NodePool support a list of LANs where the nodes should be connected to (create and update). Added in code and docs.